### PR TITLE
brcm-patchram-plus: Use low power mode profile for smelt.

### DIFF
--- a/recipes-android/brcm-patchram-plus/brcm-patchram-plus_git.bbappend
+++ b/recipes-android/brcm-patchram-plus/brcm-patchram-plus_git.bbappend
@@ -1,3 +1,3 @@
 FILESEXTRAPATHS_prepend_smelt := "${THISDIR}/brcm-patchram-plus:"
 SRC_URI_append_smelt = " file://patchram.service "
-CFLAGS_append_smelt = " -DLPM_STURGEON"
+CFLAGS_append_smelt = " -DLPM_SMELT"


### PR DESCRIPTION
sturgeon and smelt seem to have similar bt profiles:
https://github.com/AsteroidOS/brcm-patchram-plus/blob/master/src/main.c#L251

Forgot to change this while porting.