### PR TITLE
android-init: Allow mdss CX to go to Vdd min on idle.

### DIFF
--- a/recipes-android/android-init/android-init/init.rc
+++ b/recipes-android/android-init/android-init/init.rc
@@ -5,6 +5,8 @@ on init
     symlink /dev/fb0 /dev/graphics/fb0
     chown system root /sys/class/timed_output/vibrator/enable
 
+    write /sys/kernel/debug/mdp/allow_cx_vddmin 1
+
     class_start core
 
 service logd /system/bin/logd


### PR DESCRIPTION
This reduces power cost when in ambient mode.

This line also exists in init.smelt.rc. On sturgeon it explicitly states that it reduces ambient mode power cost.

This should help improve battery life in idle and ambient mode.